### PR TITLE
PM-673 dynamic code evaluation

### DIFF
--- a/vanilla/js/global.js
+++ b/vanilla/js/global.js
@@ -988,7 +988,8 @@ jQuery(document).ready(function($) {
                         informMessages.prependTrigger('<div class="' + css + '"' + elementId + '>' + message + '</div>');
                         // Is there a callback or callback url to request on dismiss of the inform message?
                         if (dismissCallback) {
-                            $('div.InformWrapper:first').find('a.Close').click(eval(dismissCallback));
+                            $('div.InformWrapper:first').find('a.Close').click();
+                            console.error('Not evaluating dismissCallback', dismissCallback);
                         } else if (dismissCallbackUrl) {
                             dismissCallbackUrl = dismissCallbackUrl.replace(/{TransientKey}/g, gdn.definition('TransientKey'));
                             var closeAnchor = $('div.InformWrapper:first').find('a.Close');


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-673
Handle "Dynamic Code Evaluation: Code Injection" security issue.
There's an `eval()` in the code that I can't find anything that can trigger it. Tried multiple scenarios, but couldn't find anything.
I removed it since we can't handle security concerns without knowing the code that we want to allow to be evaluated. I added a console.error to log any possible missed triggers (In case QA finds some issues).
